### PR TITLE
Markdown Preview Improvements

### DIFF
--- a/MDKaTeX/__init__.py
+++ b/MDKaTeX/__init__.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import re
 
 from .HTMLandCSS import HTMLforEditor, read_file, front, back, front_cloze, back_cloze, css
 from aqt import mw
@@ -12,16 +13,16 @@ CONF_NAME = "MDKATEX"
 
 def markdownPreview(editor):
     """This function runs when the user opens the editor, creates the markdown preview area"""
-    if editor.note.note_type()["name"] in [
-        MODEL_NAME + " Basic (Color)",
-        MODEL_NAME + " Cloze (Color)",
-    ]:
+    note_type = editor.note.note_type()["name"]
+    flags = re.IGNORECASE
+
+    if re.match(r".*KaTeX.*|.*Markdown.*", note_type, flags):
         editor.web.eval(HTMLforEditor)
     else:  # removes the markdown preview
         editor.web.eval(
-            """
-					var area = document.getElementById('markdown-area');
-					if(area) area.remove();
+        """
+        var area = document.getElementById('markdown-area');
+        if(area) area.remove();
         """
         )
 

--- a/MDKaTeX/js/HTMLforEditor.js
+++ b/MDKaTeX/js/HTMLforEditor.js
@@ -12,8 +12,28 @@ area.style.height = '100%';
 var fields = document.getElementById('fields');
 if (fields !== null) {
   keyupFunc = function () {
-    var text = '# Field 1\n' + fields.children[0].children[1].shadowRoot.children[2].innerHTML;
-    text += "\n# Field 2\n" + fields.children[1].children[1].shadowRoot.children[2].innerHTML;
+    var text = "";
+    var childElements = fields.children;
+
+    for (var i = 0; i < childElements.length; i++) {
+      var element = childElements[i];
+      var richTextElement = element.children[1];
+
+      // Display field if richTextElement exists
+      if (richTextElement && richTextElement.shadowRoot) {
+        var shadowRootChildren = richTextElement.shadowRoot.children;
+
+        if (shadowRootChildren.length >= 3) {
+          var field_text = shadowRootChildren[2].innerHTML;
+          var field_name = element.getElementsByClassName("label-name")[0].textContent;
+
+          // Only display non-empty fields
+          if (field_text.trim() !== '' && field_text.trim() !== '<br>') {
+            text += `\n# ${field_name}\n` + field_text;
+          }
+        }
+      }
+    }
     render(text);
   }
 
@@ -24,8 +44,28 @@ else {
   var fields = document.getElementsByClassName('fields')[0];
 
   keyupFunc = function () {
-    var text = '# Field 1\n' + fields.children[0].getElementsByClassName("rich-text-editable")[0].shadowRoot.children[2].innerHTML;
-    text += "\n# Field 2\n" + fields.children[1].getElementsByClassName("rich-text-editable")[0].shadowRoot.children[2].innerHTML;
+    var text = "";
+    var childElements = fields.children;
+
+    for (var i = 0; i < childElements.length; i++) {
+      var element = childElements[i];
+      var richTextElement = element.getElementsByClassName("rich-text-editable")[0];
+
+      // Display field if richTextElement exists
+      if (richTextElement && richTextElement.shadowRoot) {
+        var shadowRootChildren = richTextElement.shadowRoot.children;
+
+        if (shadowRootChildren.length >= 3) {
+          var field_text = shadowRootChildren[2].innerHTML;
+          var field_name = element.getElementsByClassName("label-name")[0].textContent;
+
+          // Only display non-empty fields
+          if (field_text.trim() !== '' && field_text.trim() !== '<br>') {
+            text += `\n# ${field_name}\n` + field_text;
+          }
+        }
+      }
+    }
     render(text);
   }
 


### PR DESCRIPTION
I've been wanting to make these improvements for a while now. I'm glad I finally sat down and did them :]

## Changes
- Display editor for any note types which have `KaTeX` or `Markdown` in their names. This means that users can clone the default note types and rename them to more functional titles, like: `Markdown: Programming`
-  Use field titles for the preview and don't limit the fields to only 2, which makes the preview cleaner and more readable.

## Comparison

### Before

- **No preview if the note type is not the default**

![Screenshot from 2024-05-31 01-01-54](https://github.com/alexthillen/Anki-KaTeX-Markdown-Reworked/assets/83901271/69868131-4199-47de-95a6-33af478bef9f)

- **No preview beyond the first two fields, which have generic names**

![Screenshot from 2024-05-31 01-06-56](https://github.com/alexthillen/Anki-KaTeX-Markdown-Reworked/assets/83901271/7cbf89a6-03d4-41c5-84fa-01f33777db3a)

### After

- **Fields with proper names and support for multiple fields**
![Screenshot from 2024-05-31 00-55-56](https://github.com/alexthillen/Anki-KaTeX-Markdown-Reworked/assets/83901271/d30301e9-eb22-4f20-9cae-498816f2140e)